### PR TITLE
Add method to specify config location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +122,7 @@ version = "0.1.0"
 dependencies = [
  "b2_backblaze",
  "chrono",
+ "clap",
  "serde",
  "tokio",
  "toml",
@@ -143,6 +192,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.52.4",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-foundation"
@@ -329,6 +424,12 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -939,6 +1040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "syn"
 version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1275,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backup"
-description = "An automated backup tool to dump MariaDB databases and uploa them to a Backblaze S3 bucket"
+description = "An automated backup tool to dump MariaDB databases and upload them to a Backblaze S3 bucket"
 version = "0.1.0"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "backup"
+description = "An automated backup tool to dump MariaDB databases and uploa them to a Backblaze S3 bucket"
 version = "0.1.0"
 edition = "2021"
 
@@ -8,6 +9,7 @@ edition = "2021"
 [dependencies]
 b2_backblaze = "0.1.8"
 chrono = "0.4.35"
+clap = { version = "4.5.3", features = ["derive"] }
 # dotenv = "0.15.0"
 serde = { version = "1.0.197", features = ["derive"] }
 tokio = "1.36.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,8 +68,8 @@ impl From<toml::de::Error> for Error {
     }
 }
 
-pub fn read_config() -> Result<Config, Error> {
-    let file_output = fs::read_to_string("./Config.toml")?;
+pub fn read_config(path: String) -> Result<Config, Error> {
+    let file_output = fs::read_to_string(path)?;
     let config: Config = toml::from_str(&file_output)?;
 
     Ok(config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,24 @@ mod error;
 use error::Error;
 use std::fs;
 use std::process::Command;
+use clap::Parser;
+
+#[derive(clap::Parser)]
+#[command(about, long_about = None)]
+struct Arg {
+    #[arg(short = 'c', long = "config")]
+    config_file: Option<String>,
+}
 
 #[tokio::main]
 async fn main() {
-    let config = match config::read_config() {
+    let config_file = Arg::parse();
+    let config_path = config_file.config_file.unwrap_or_else(|| {
+        println!("Using default config location: ./Config.toml");
+        String::from("./Config.toml")
+    });
+    
+    let config = match config::read_config(config_path) {
         Ok(config) => config,
         Err(err) => {
             println!("{}", err);


### PR DESCRIPTION
This PR just adds a simple CLI interface, using `clap`, that allows specifying an alternate location for a config file. Can be useful in a cron context since the config file can now live elsewhere.